### PR TITLE
feat: build static apps before deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /node_modules/
+/static/*/node_modules/
+/static/*/build/
 /dist/
 /.vscode/
 .idea

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint src/**/* || npm run --silent hook-errors",
     "hook-errors": "echo '\\x1b[31mThe build failed because a Forge UI hook is being used incorrectly. Forge UI hooks follow the same rules as React Hooks but have their own API definitions. See the Forge documentation for details on how to use Forge UI hooks.\n' && exit 1",
     "build": "npm --prefix static/configurable-validation run build && npm --prefix static/edit run build && npm --prefix static/traffic-view run build",
-    "predeploy": "node scripts/check-resources.js"
+    "predeploy": "node scripts/predeploy.js"
   },
   "devDependencies": {
     "eslint": "^8.56.0",

--- a/scripts/predeploy.js
+++ b/scripts/predeploy.js
@@ -1,0 +1,22 @@
+const { execSync } = require('child_process');
+
+const apps = [
+  'static/configurable-validation',
+  'static/edit',
+  'static/traffic-view',
+];
+
+for (const app of apps) {
+  try {
+    console.log(`[predeploy] Installing dependencies in ${app}...`);
+    execSync(`npm --prefix ${app} install`, { stdio: 'inherit' });
+    console.log(`[predeploy] Building ${app}...`);
+    execSync(`npm --prefix ${app} run build`, { stdio: 'inherit' });
+  } catch (err) {
+    console.error(`[predeploy] Failed for ${app}`);
+    process.exitCode = 1;
+    throw err;
+  }
+}
+
+require('./check-resources');


### PR DESCRIPTION
## Summary
- run a predeploy script that installs and builds all static apps
- ignore static build and node_modules directories in git

## Testing
- `npm run lint`
- `node scripts/predeploy.js`

------
https://chatgpt.com/codex/tasks/task_e_68a5bc8259c88330b14667ef026d99e0